### PR TITLE
Add example for basic elixir project

### DIFF
--- a/basic_elixir/.dockerignore
+++ b/basic_elixir/.dockerignore
@@ -1,0 +1,9 @@
+# The directory Mix will write compiled artifacts to.
+_build/
+
+# The directory Mix downloads your dependencies sources to.
+deps/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+

--- a/basic_elixir/.formatter.exs
+++ b/basic_elixir/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/basic_elixir/.gitignore
+++ b/basic_elixir/.gitignore
@@ -1,0 +1,24 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+basic_elixir-*.tar
+

--- a/basic_elixir/Dockerfile
+++ b/basic_elixir/Dockerfile
@@ -1,0 +1,13 @@
+FROM elixir:1.9-alpine as builder
+RUN mix local.hex --force && mix local.rebar --force
+WORKDIR /app
+COPY . /app
+RUN mix deps.get
+RUN MIX_ENV=prod mix release
+
+FROM alpine:latest as app
+RUN apk add bash openssl
+WORKDIR /app
+COPY --from=builder /app/_build/prod/rel/basic_elixir .
+CMD bin/basic_elixir start
+

--- a/basic_elixir/Dockerfile
+++ b/basic_elixir/Dockerfile
@@ -5,19 +5,7 @@ RUN mix local.hex --force && mix local.rebar --force
 WORKDIR /app
 COPY . /app
 RUN mix deps.get
-# Need to compile opentelemetry_api first, else will
-# face compilation error when trying to compile opentelemetry
-# with the following trace:
-#
-# ===> Compiling opentelemetry
-# ===> Compiling src/otel_sampler.erl failed
-# src/otel_sampler.erl:29: can't find include lib "opentelemetry_api/include/opentelemetry.hrl"
-# src/otel_sampler.erl:85: undefined macro 'IS_SPAN_ENABLED/1'
-# src/otel_sampler.erl:100: undefined macro 'IS_SPAN_ENABLED/1'
-RUN mix deps.compile opentelemetry_api \
-  && mix deps.compile opentelemetry \
-  && mix deps.compile \
-  && MIX_ENV=prod mix release
+RUN MIX_ENV=prod mix release
 
 FROM alpine:latest as app
 RUN apk add bash openssl

--- a/basic_elixir/Dockerfile
+++ b/basic_elixir/Dockerfile
@@ -1,9 +1,23 @@
 FROM elixir:1.9-alpine as builder
+# Add git as deps to fetch dependencies through git directly
+RUN apk add git
 RUN mix local.hex --force && mix local.rebar --force
 WORKDIR /app
 COPY . /app
 RUN mix deps.get
-RUN MIX_ENV=prod mix release
+# Need to compile opentelemetry_api first, else will
+# face compilation error when trying to compile opentelemetry
+# with the following trace:
+#
+# ===> Compiling opentelemetry
+# ===> Compiling src/otel_sampler.erl failed
+# src/otel_sampler.erl:29: can't find include lib "opentelemetry_api/include/opentelemetry.hrl"
+# src/otel_sampler.erl:85: undefined macro 'IS_SPAN_ENABLED/1'
+# src/otel_sampler.erl:100: undefined macro 'IS_SPAN_ENABLED/1'
+RUN mix deps.compile opentelemetry_api \
+  && mix deps.compile opentelemetry \
+  && mix deps.compile \
+  && MIX_ENV=prod mix release
 
 FROM alpine:latest as app
 RUN apk add bash openssl

--- a/basic_elixir/Dockerfile
+++ b/basic_elixir/Dockerfile
@@ -1,6 +1,4 @@
 FROM elixir:1.9-alpine as builder
-# Add git as deps to fetch dependencies through git directly
-RUN apk add git
 RUN mix local.hex --force && mix local.rebar --force
 WORKDIR /app
 COPY . /app

--- a/basic_elixir/README.md
+++ b/basic_elixir/README.md
@@ -1,0 +1,21 @@
+# BasicElixir
+
+**TODO: Add description**
+
+## Installation
+
+If [available in Hex](https://hex.pm/docs/publish), the package can be installed
+by adding `basic_elixir` to your list of dependencies in `mix.exs`:
+
+```elixir
+def deps do
+  [
+    {:basic_elixir, "~> 0.1.0"}
+  ]
+end
+```
+
+Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
+and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
+be found at [https://hexdocs.pm/basic_elixir](https://hexdocs.pm/basic_elixir).
+

--- a/basic_elixir/README.md
+++ b/basic_elixir/README.md
@@ -1,21 +1,21 @@
-# BasicElixir
+# Basic Elixir Example
 
-**TODO: Add description**
+This is a sample repository that demo how to setup a basic Elixir application
+with `opentelemetry-api` and `opentelemetry_exporter`. Here, we are using
+`opentelemetry_exporter` to export the traces to [OpenTelemetry Collector][0].
+The collector in turn export the traces to [Zipkin][1] and [Jaeger][2]
+respectively.
 
-## Installation
+## Getting Stated
 
-If [available in Hex](https://hex.pm/docs/publish), the package can be installed
-by adding `basic_elixir` to your list of dependencies in `mix.exs`:
+Assuming you already have Docker and Docker Compose installed:
 
-```elixir
-def deps do
-  [
-    {:basic_elixir, "~> 0.1.0"}
-  ]
-end
-```
+1. Run `docker-compose up` to start the application, OpenTelemetry Collector,
+   Zipkin and Jaegar.
+2. Visit Zipkin at http://localhost:9411 and hit `Run Query` to look the the sample trace.
+3. Visit Jaeger UI at http://localhost:16686 and click `Find Trace` to look at the sample
+   trace.
 
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at [https://hexdocs.pm/basic_elixir](https://hexdocs.pm/basic_elixir).
-
+[0]: https://github.com/open-telemetry/opentelemetry-collector/
+[1]: https://zipkin.io/
+[2]: https://www.jaegertracing.io/

--- a/basic_elixir/config/releases.exs
+++ b/basic_elixir/config/releases.exs
@@ -1,0 +1,12 @@
+import Config
+
+config :opentelemetry,
+       :processors,
+       otel_batch_processor: %{
+         # Using `otel` here since we are starting through docker-compose where
+         # otel refer to the hostname of the OpenCollector,
+         #
+         # If you are running it locally, kindly change it to the correct
+         # hostname such as `localhost`, `0.0.0.0` and etc.
+         exporter: {:opentelemetry_exporter, %{endpoints: [{:http, 'otel', 55681, []}]}}
+       }

--- a/basic_elixir/docker-compose.yml
+++ b/basic_elixir/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  elixir:
+    build: .
+
+  otel:
+    image: otel/opentelemetry-collector-contrib-dev:latest
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    ports:
+      - '55681:55681'
+      - '55680:55680'
+    volumes:
+      - ./otel-collector-config.yaml:/etc/otel-collector-config.yaml
+
+  zipkin:
+    image: openzipkin/zipkin-slim
+    ports:
+      - '9411:9411'
+
+  # Jaeger
+  jaeger-all-in-one:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - "16686:16686"
+      - "14268"
+      - "14250"
+
+

--- a/basic_elixir/lib/basic_elixir.ex
+++ b/basic_elixir/lib/basic_elixir.ex
@@ -1,0 +1,18 @@
+defmodule BasicElixir do
+  @moduledoc """
+  Documentation for BasicElixir.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> BasicElixir.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/basic_elixir/lib/basic_elixir/application.ex
+++ b/basic_elixir/lib/basic_elixir/application.ex
@@ -1,0 +1,19 @@
+defmodule BasicElixir.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      # Starts a worker by calling: BasicElixir.Worker.start_link(arg)
+      # {BasicElixir.Worker, arg}
+    ]
+
+    # See https://hexdocs.pm/elixir/Supervisor.html
+    # for other strategies and supported options
+    opts = [strategy: :one_for_one, name: BasicElixir.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/basic_elixir/lib/basic_elixir/application.ex
+++ b/basic_elixir/lib/basic_elixir/application.ex
@@ -8,7 +8,7 @@ defmodule BasicElixir.Application do
   def start(_type, _args) do
     children = [
       # Starts a worker by calling: BasicElixir.Worker.start_link(arg)
-      # {BasicElixir.Worker, arg}
+      {BasicElixir.Worker, []}
     ]
 
     # See https://hexdocs.pm/elixir/Supervisor.html

--- a/basic_elixir/lib/basic_elixir/application.ex
+++ b/basic_elixir/lib/basic_elixir/application.ex
@@ -11,6 +11,8 @@ defmodule BasicElixir.Application do
       {BasicElixir.Worker, []}
     ]
 
+    OpenTelemetry.register_application_tracer(:basic_elixir)
+
     # See https://hexdocs.pm/elixir/Supervisor.html
     # for other strategies and supported options
     opts = [strategy: :one_for_one, name: BasicElixir.Supervisor]

--- a/basic_elixir/lib/basic_elixir/worker.ex
+++ b/basic_elixir/lib/basic_elixir/worker.ex
@@ -1,10 +1,14 @@
 defmodule BasicElixir.Worker do
   use GenServer
   require Logger
+  require OpenTelemetry.Tracer
+  require OpenTelemetry.Span
 
   # Client
   def start_link(default) when is_list(default) do
-    GenServer.start_link(__MODULE__, default)
+    OpenTelemetry.Tracer.with_span "start_link" do
+      GenServer.start_link(__MODULE__, default)
+    end
   end
 
   def push(pid, element) do
@@ -18,8 +22,10 @@ defmodule BasicElixir.Worker do
   # Server (callbacks)
   @impl true
   def init(stack) do
-    Logger.info("Starting #{__MODULE__}...")
-    {:ok, stack}
+    OpenTelemetry.Tracer.with_span "init" do
+      Logger.info("Starting #{__MODULE__}...")
+      {:ok, stack}
+    end
   end
 
   @impl true

--- a/basic_elixir/lib/basic_elixir/worker.ex
+++ b/basic_elixir/lib/basic_elixir/worker.ex
@@ -1,0 +1,34 @@
+defmodule BasicElixir.Worker do
+  use GenServer
+  require Logger
+
+  # Client
+  def start_link(default) when is_list(default) do
+    GenServer.start_link(__MODULE__, default)
+  end
+
+  def push(pid, element) do
+    GenServer.cast(pid, {:push, element})
+  end
+
+  def pop(pid) do
+    GenServer.call(pid, :pop)
+  end
+
+  # Server (callbacks)
+  @impl true
+  def init(stack) do
+    Logger.info("Starting #{__MODULE__}...")
+    {:ok, stack}
+  end
+
+  @impl true
+  def handle_call(:pop, _from, [head | tail]) do
+    {:reply, head, tail}
+  end
+
+  @impl true
+  def handle_cast({:push, element}, state) do
+    {:noreply, [element | state]}
+  end
+end

--- a/basic_elixir/lib/basic_elixir/worker.ex
+++ b/basic_elixir/lib/basic_elixir/worker.ex
@@ -7,6 +7,8 @@ defmodule BasicElixir.Worker do
   # Client
   def start_link(default) when is_list(default) do
     OpenTelemetry.Tracer.with_span "start_link" do
+      span_ctx = OpenTelemetry.Tracer.current_span_ctx
+      OpenTelemetry.Span.set_attribute(span_ctx, "hello", "world")
       GenServer.start_link(__MODULE__, default)
     end
   end

--- a/basic_elixir/mix.exs
+++ b/basic_elixir/mix.exs
@@ -7,7 +7,12 @@ defmodule BasicElixir.MixProject do
       version: "0.1.0",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      releases: [
+        basic_elixir: [
+          applications: [opentelemetry: :temporary]
+        ]
+      ]
     ]
   end
 

--- a/basic_elixir/mix.exs
+++ b/basic_elixir/mix.exs
@@ -27,15 +27,8 @@ defmodule BasicElixir.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:opentelemetry_api,
-       github: "open-telemetry/opentelemetry-erlang", sparse: "apps/opentelemetry_api"},
-      {:opentelemetry,
-       github: "open-telemetry/opentelemetry-erlang", sparse: "apps/opentelemetry"},
-      {:opentelemetry_exporter,
-       github: "open-telemetry/opentelemetry-erlang", sparse: "apps/opentelemetry_exporter"}
-
-      # {:dep_from_hexpm, "~> 0.3.0"},
-      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+      {:opentelemetry, "~> 0.5.0"},
+      {:opentelemetry_exporter, "~> 0.5.0"},
     ]
   end
 end

--- a/basic_elixir/mix.exs
+++ b/basic_elixir/mix.exs
@@ -22,6 +22,13 @@ defmodule BasicElixir.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:opentelemetry_api,
+       github: "open-telemetry/opentelemetry-erlang", sparse: "apps/opentelemetry_api"},
+      {:opentelemetry,
+       github: "open-telemetry/opentelemetry-erlang", sparse: "apps/opentelemetry"},
+      {:opentelemetry_exporter,
+       github: "open-telemetry/opentelemetry-erlang", sparse: "apps/opentelemetry_exporter"}
+
       # {:dep_from_hexpm, "~> 0.3.0"},
       # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
     ]

--- a/basic_elixir/mix.exs
+++ b/basic_elixir/mix.exs
@@ -1,0 +1,29 @@
+defmodule BasicElixir.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :basic_elixir,
+      version: "0.1.0",
+      elixir: "~> 1.9",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {BasicElixir.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      # {:dep_from_hexpm, "~> 0.3.0"},
+      # {:dep_from_git, git: "https://github.com/elixir-lang/my_dep.git", tag: "0.1.0"}
+    ]
+  end
+end

--- a/basic_elixir/mix.lock
+++ b/basic_elixir/mix.lock
@@ -1,0 +1,11 @@
+%{
+  "acceptor_pool": {:hex, :acceptor_pool, "1.0.0", "43c20d2acae35f0c2bcd64f9d2bde267e459f0f3fd23dab26485bf518c281b21", [:rebar3], [], "hexpm"},
+  "chatterbox": {:hex, :ts_chatterbox, "0.9.1", "843557ee729b04b3c1bdac33fb162daefdbf4f7ae0af0bdc055fb16e91e057e3", [:rebar3], [{:hpack, "~>0.2.3", [hex: :hpack_erl, repo: "hexpm", optional: false]}], "hexpm"},
+  "ctx": {:hex, :ctx, "0.5.0", "78e0f16712e12d707a7f34277381b8e193d7c71eaa24d37330dc02477c09eda5", [:rebar3], [], "hexpm"},
+  "gproc": {:hex, :gproc, "0.8.0", "cea02c578589c61e5341fce149ea36ccef236cc2ecac8691fba408e7ea77ec2f", [:rebar3], [], "hexpm"},
+  "grpcbox": {:hex, :grpcbox, "0.11.0", "ea9f9160120a4884838d397dde64b36edb122adf335238f639debc12087da67f", [:rebar3], [{:acceptor_pool, "~>1.0.0", [hex: :acceptor_pool, repo: "hexpm", optional: false]}, {:chatterbox, "~>0.9.1", [hex: :ts_chatterbox, repo: "hexpm", optional: false]}, {:ctx, "~>0.5.0", [hex: :ctx, repo: "hexpm", optional: false]}, {:gproc, "~>0.8.0", [hex: :gproc, repo: "hexpm", optional: false]}], "hexpm"},
+  "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [:rebar3], [], "hexpm"},
+  "opentelemetry": {:git, "https://github.com/open-telemetry/opentelemetry-erlang.git", "3d12c5180768b24830dff69af1fd0abd5307384b", [sparse: "apps/opentelemetry"]},
+  "opentelemetry_api": {:git, "https://github.com/open-telemetry/opentelemetry-erlang.git", "3d12c5180768b24830dff69af1fd0abd5307384b", [sparse: "apps/opentelemetry_api"]},
+  "opentelemetry_exporter": {:git, "https://github.com/open-telemetry/opentelemetry-erlang.git", "3d12c5180768b24830dff69af1fd0abd5307384b", [sparse: "apps/opentelemetry_exporter"]},
+}

--- a/basic_elixir/mix.lock
+++ b/basic_elixir/mix.lock
@@ -5,7 +5,7 @@
   "gproc": {:hex, :gproc, "0.8.0", "cea02c578589c61e5341fce149ea36ccef236cc2ecac8691fba408e7ea77ec2f", [:rebar3], [], "hexpm"},
   "grpcbox": {:hex, :grpcbox, "0.11.0", "ea9f9160120a4884838d397dde64b36edb122adf335238f639debc12087da67f", [:rebar3], [{:acceptor_pool, "~>1.0.0", [hex: :acceptor_pool, repo: "hexpm", optional: false]}, {:chatterbox, "~>0.9.1", [hex: :ts_chatterbox, repo: "hexpm", optional: false]}, {:ctx, "~>0.5.0", [hex: :ctx, repo: "hexpm", optional: false]}, {:gproc, "~>0.8.0", [hex: :gproc, repo: "hexpm", optional: false]}], "hexpm"},
   "hpack": {:hex, :hpack_erl, "0.2.3", "17670f83ff984ae6cd74b1c456edde906d27ff013740ee4d9efaa4f1bf999633", [:rebar3], [], "hexpm"},
-  "opentelemetry": {:git, "https://github.com/open-telemetry/opentelemetry-erlang.git", "3d12c5180768b24830dff69af1fd0abd5307384b", [sparse: "apps/opentelemetry"]},
-  "opentelemetry_api": {:git, "https://github.com/open-telemetry/opentelemetry-erlang.git", "3d12c5180768b24830dff69af1fd0abd5307384b", [sparse: "apps/opentelemetry_api"]},
-  "opentelemetry_exporter": {:git, "https://github.com/open-telemetry/opentelemetry-erlang.git", "3d12c5180768b24830dff69af1fd0abd5307384b", [sparse: "apps/opentelemetry_exporter"]},
+  "opentelemetry": {:hex, :opentelemetry, "0.5.0", "6a7072a6f54b8be07a42dd2aaca1ee0389038681405d0a27c4c5e5325b6c1a82", [:rebar3], [{:opentelemetry_api, "~>0.5.0", [hex: :opentelemetry_api, repo: "hexpm", optional: false]}], "hexpm"},
+  "opentelemetry_api": {:hex, :opentelemetry_api, "0.5.0", "29ecaa7bb86df4dbd44b14fd71fd4faadff5c08d178545b66b3861bd350be28a", [:mix, :rebar3], [], "hexpm"},
+  "opentelemetry_exporter": {:hex, :opentelemetry_exporter, "0.5.0", "71c32f865123aeb7f72e15a1a8dddbbf868f07a5d65795d8f5d909b36fddc7be", [:rebar3], [{:grpcbox, "~>0.11.0", [hex: :grpcbox, repo: "hexpm", optional: false]}, {:opentelemetry, "~>0.5.0", [hex: :opentelemetry, repo: "hexpm", optional: false]}, {:opentelemetry_api, "~>0.5.0", [hex: :opentelemetry_api, repo: "hexpm", optional: false]}], "hexpm"},
 }

--- a/basic_elixir/otel-collector-config.yaml
+++ b/basic_elixir/otel-collector-config.yaml
@@ -1,0 +1,27 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: "0.0.0.0:55680"
+      http:
+        endpoint: "0.0.0.0:55681"
+processors:
+  batch:
+    send_batch_size: 1024
+    timeout: 5s
+exporters:
+  zipkin:
+    endpoint: "http://zipkin:9411/api/v2/spans"
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    insecure: true
+extensions:
+  zpages: {}
+service:
+  extensions: [zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [zipkin, jaeger]
+

--- a/basic_elixir/test/basic_elixir_test.exs
+++ b/basic_elixir/test/basic_elixir_test.exs
@@ -1,0 +1,8 @@
+defmodule BasicElixirTest do
+  use ExUnit.Case
+  doctest BasicElixir
+
+  test "greets the world" do
+    assert BasicElixir.hello() == :world
+  end
+end

--- a/basic_elixir/test/test_helper.exs
+++ b/basic_elixir/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()


### PR DESCRIPTION
This PR aims to address the issue #5, which is to add basic Elixir project with simple span creation and use of Otel Exporter.

Since, `opentelemetry` haven't make a new release yet, we will be using mix's `sparse` feature when adding the dependencies.

## Todo

- [X] Add README.md

## Updates (21/11/2020)

Since the version `0.0.5` for `opentelemetry` and `opentelemtry_exporter` has been released into `hex`, the below problems are no longer an issue. 

## Problems & Quick Fixes
In the process of using the dependencies from `git`, I have face some compilation error and have to hack it with some fixes as follow:

### Dockerfile
In the `Dockerfile`, we explicitly compile the dependencies with the following order:

```dockerfile
RUN mix deps.compile opentelemetry_api \
  && mix deps.compile opentelemetry \
  && mix deps.compile \
  && MIX_ENV=prod mix release
```

to ensure we can build the image successfully. This is because, at the time of writing this PR, without specifying the order explicitly, we would get the following error when building the release:

```
===> Compiling opentelemetry
===> Compiling src/otel_sampler.erl failed
src/otel_sampler.erl:29: can't find include lib "opentelemetry_api/include/opentelemetry.hrl"
src/otel_sampler.erl:85: undefined macro 'IS_SPAN_ENABLED/1'
src/otel_sampler.erl:100: undefined macro 'IS_SPAN_ENABLED/1'
```

same for when compiling `opentelemetry_exporter`, which require some `hrl` file from `opentelemetry`.

### Adding `opentelemetry` as mix dependency
As mention above, while compiling `openteleemtry_exporter` without `opentelemetry`, there will be compilation error as follow:

```
===> Compiling acceptor_pool
===> Compiling gproc
src/gproc_dist.erl:25: Warning: behaviour gen_leader undefined
src/gproc_dist.erl:553: Warning: erlang:get_stacktrace/0: deprecated; use the new try/catch syntax for retrieving the stack backtrace

===> Compiling hpack
===> Compiling chatterbox
===> Compiling ctx
===> Compiling grpcbox
===> Compiling opentelemetry_exporter
===> Compiling src/opentelemetry_exporter.erl failed
src/opentelemetry_exporter.erl:13: can't find include lib "opentelemetry/include/otel_span.hrl"; Make sure 
opentelemetry is in your app file's 'applications' list

src/opentelemetry_exporter.erl:97: record instrumentation_library undefined
src/opentelemetry_exporter.erl:99: variable 'Name' is unbound
src/opentelemetry_exporter.erl:100: variable 'Version' is unbound
src/opentelemetry_exporter.erl:107: record span undefined
src/opentelemetry_exporter.erl:121: variable 'MaybeParentSpanId' is unbound
src/opentelemetry_exporter.erl:122: variable 'Name' is unbound
src/opentelemetry_exporter.erl:123: variable 'TraceId' is unbound
src/opentelemetry_exporter.erl:124: variable 'SpanId' is unbound
src/opentelemetry_exporter.erl:126: variable 'TraceState' is unbound
src/opentelemetry_exporter.erl:127: variable 'Kind' is unbound
src/opentelemetry_exporter.erl:128: variable 'StartTime' is unbound
src/opentelemetry_exporter.erl:129: variable 'EndTime' is unbound
src/opentelemetry_exporter.erl:130: variable 'Attributes' is unbound
src/opentelemetry_exporter.erl:132: variable 'TimedEvents' is unbound
src/opentelemetry_exporter.erl:134: variable 'Links' is unbound
src/opentelemetry_exporter.erl:136: variable 'Status' is unbound

** (Mix) Could not compile dependency :opentelemetry_exporter, "/root/.mix/rebar3 bare compile 
--paths="/app/_build/dev/lib/*/ebin"" command failed. You can recompile this dependency with 
"mix deps.compile opentelemetry_exporter", update it with "mix deps.update opentelemetry_exporter" or clean it 
with "mix deps.clean opentelemetry_exporter"
```

However, I believe this could be fix in upstream or when we use proper hex package when the new release is available. But for the time being, these are some hacks to glue it all together.

