### PR TITLE
Fix typo in basic_elixir/README: Jaegar -> Jaeger

### DIFF
--- a/basic_elixir/README.md
+++ b/basic_elixir/README.md
@@ -11,7 +11,7 @@ respectively.
 Assuming you already have Docker and Docker Compose installed:
 
 1. Run `docker-compose up` to start the application, OpenTelemetry Collector,
-   Zipkin and Jaegar.
+   Zipkin and Jaeger.
 2. Visit Zipkin at http://localhost:9411 and hit `Run Query` to look the the sample trace.
 3. Visit Jaeger UI at http://localhost:16686 and click `Find Trace` to look at the sample
    trace.


### PR DESCRIPTION
This fix a simple typoe in one of the README.